### PR TITLE
Added command line parsing using Docopt 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 authors = ["Feryla"]
 
 [dependencies]
+docopt = "0.6"
+rustc-serialize = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+extern crate rustc_serialize;
+extern crate docopt;
+
+
 mod romloader;
 mod disassembler;
 mod cpu {
@@ -8,10 +12,31 @@ mod cpu {
 
 use cpu::cpu::CPU;
 use std::process;
+use docopt::Docopt;
+const USAGE: &'static str = "
+Ate zero
 
+Usage:
+  atezero [--rom <path_to_rom>]
+
+Options:
+  -h --help             Show this screen.
+  --version             Show version.
+  --rom=<path_to_rom>   Path to ROM to execute [default: mem.rom]
+";
+
+#[derive(Debug, RustcDecodable)]
+struct Args {
+    flag_rom: String,
+}
 
 fn main() {
-    let rom = romloader::load();
+
+    let args: Args = Docopt::new(USAGE)
+                            .and_then(|d| d.decode())
+                            .unwrap_or_else(|e| e.exit());
+    
+    let rom = romloader::load(&args.flag_rom);
     let mut cpu: CPU = Default::default();
 
     cpu.load_rom(rom);

--- a/src/romloader.rs
+++ b/src/romloader.rs
@@ -1,8 +1,12 @@
 use std::fs::File;
 use std::io::Read;
+use std::process::exit;
 
-pub fn load() -> Vec<u8> {
-    let mut f = File::open("../res/invaders.rom").unwrap();
+pub fn load(path: &String) -> Vec<u8> {
+    let mut f:File = match File::open(path) {
+        Ok(f) => { f }
+        Err(e) => { println!("Error opening rom file '{}': {}", path, e); exit(-1);}
+    };
     let mut buffer = Vec::new();
     f.read_to_end(&mut buffer).unwrap();
     return buffer;


### PR DESCRIPTION
Running the program now takes an option --rom specifying the path to the rom file,
defaulting to mem.rom in the current directory.